### PR TITLE
fix: ignore mime type control when file have no mime type

### DIFF
--- a/app/components/ui/file-upload.ts
+++ b/app/components/ui/file-upload.ts
@@ -22,7 +22,7 @@ export default class UiFileUpload extends Component<UiFileUploadArgs> {
   }
 
   processFile(file: File) {
-    if (this.args.mimeTypes && !this.args.mimeTypes.includes(file.type)) {
+    if (file.type && this.args.mimeTypes && !this.args.mimeTypes.includes(file.type)) {
       if (this.args.mimeTypeError) {
         alert(this.args.mimeTypeError)
       }


### PR DESCRIPTION
Sometime (on windows only?) when selecting a font file, the file have no mime type & it prevent the file to be use as font givent there's a mime type check on file-upload component.

The mime type control is now ignore when the file doesn't have mime type & the font will fail to load if it's not a valid font file.